### PR TITLE
Add parentheses to 0-arity functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can learn more about the history, purpose and implementation of Styler from 
 
 ## Who is Styler for?
 
-Styler was designed for a **large team (40+ engineers) working in a single codebase. It helps remove fiddly code review comments and removes failed linter CI slowdowns, helping teams get things done faster. Teams in similar situations might appreciate Styler.
+Styler was designed for a \*\*large team (40+ engineers) working in a single codebase. It helps remove fiddly code review comments and removes failed linter CI slowdowns, helping teams get things done faster. Teams in similar situations might appreciate Styler.
 
 Its automations are also extremely valuable for taming legacy elixir codebases or just refactoring in general. Some of its rewrites have inspired code actions in elixir language servers.
 
@@ -66,18 +66,16 @@ Styler can be configured in your `.formatter.exs` file
 [
   plugins: [Styler],
   styler: [
-    alias_lifting_exclude: [...]
+    alias_lifting_exclude: [...],
+    zero_arity_parens: true
   ]
 ]
 ```
 
-Styler's only current configuration option is `:alias_lifting_exclude`, which accepts a list of atoms to _not_ lift. See the [Module Directive documentation](docs/module_directives.md#alias-lifting) for more.
+Styler has two configuration options:
 
-#### No Credo-Style Enable/Disable
-
-Styler [will not add configuration](https://github.com/adobe/elixir-styler/pull/127#issuecomment-1912242143) for ad-hoc enabling/disabling of rewrites. Sorry! Its implementation simply does not support that approach. There are however many forks out there that have attempted this; please explore the [Github forks tab](https://github.com/adobe/elixir-styler/forks) to see if there's a project that suits your needs or that you can draw inspiration from.
-
-Ultimately Styler is @adobe's internal tool that we're happy to share with the world. We're delighted if you like it as is, and just as excited if it's a starting point for you to make something even better for yourself.
+- `:alias_lifting_exclude`, which accepts a list of atoms to _not_ lift. See the [Module Directive documentation](docs/module_directives.md#alias-lifting) for more.
+- `:zero_arity_parens`, which controls whether or not zero-arity functions should have parens. Defaults to false. See the [Single Node documentation](docs/styles.md#remove-or-add-parenthesis-from-0-arity-functions-and-macro-definitions) for more.
 
 ## WARNING: Styler can change the behaviour of your program!
 

--- a/README.md
+++ b/README.md
@@ -66,16 +66,14 @@ Styler can be configured in your `.formatter.exs` file
 [
   plugins: [Styler],
   styler: [
-    alias_lifting_exclude: [...],
-    zero_arity_parens: true
+    alias_lifting_exclude: [...]
   ]
 ]
 ```
 
-Styler has two configuration options:
+Styler has one configuration options:
 
 - `:alias_lifting_exclude`, which accepts a list of atoms to _not_ lift. See the [Module Directive documentation](docs/module_directives.md#alias-lifting) for more.
-- `:zero_arity_parens`, which controls whether or not zero-arity functions should have parens. Defaults to false. See the [Single Node documentation](docs/styles.md#remove-or-add-parenthesis-from-0-arity-functions-and-macro-definitions) for more.
 
 ## WARNING: Styler can change the behaviour of your program!
 

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -25,14 +25,14 @@ Formatter already does this except it doesn't rewrite "typos" like `100_000_0`.
 If you're concerned that this breaks your team's formatting for things like "cents" (like "$100" being written as `100_00`),
 consider using a library made for denoting currencies rather than raw elixir integers.
 
-| Before | After |
-|--------|-------|
-| `10000 ` | `10_000`|
-| `1_0_0_0_0` | `10_000` (elixir's formatter leaves the former as-is)|
-| `-543213 ` | `-543_213`|
-| `123456789 ` | `123_456_789`|
-| `55333.22 ` | `55_333.22`|
-| `-123456728.0001 ` | `-123_456_728.0001`|
+| Before             | After                                                 |
+| ------------------ | ----------------------------------------------------- |
+| `10000 `           | `10_000`                                              |
+| `1_0_0_0_0`        | `10_000` (elixir's formatter leaves the former as-is) |
+| `-543213 `         | `-543_213`                                            |
+| `123456789 `       | `123_456_789`                                         |
+| `55333.22 `        | `55_333.22`                                           |
+| `-123456728.0001 ` | `-123_456_728.0001`                                   |
 
 ## `Enum.into` -> `X.new`
 
@@ -42,15 +42,15 @@ This is an improvement for the reader, who gets a more natural language expressi
 
 Note that all of the examples below also apply to pipes (`enum |> Enum.into(...)`)
 
-| Before | After |
-|--------|-------|
-| `Enum.into(enum, %{})` | `Map.new(enum)`|
-| `Enum.into(enum, Map.new())` | `Map.new(enum)`|
-| `Enum.into(enum, Keyword.new())` | `Keyword.new(enum)`|
-| `Enum.into(enum, MapSet.new())` | `Keyword.new(enum)`|
-| `Enum.into(enum, %{}, fn x -> {x, x} end)` | `Map.new(enum, fn x -> {x, x} end)`|
-| `Enum.into(enum, [])` | `Enum.to_list(enum)` |
-| `Enum.into(enum, [], mapper)` | `Enum.map(enum, mapper)`|
+| Before                                     | After                               |
+| ------------------------------------------ | ----------------------------------- |
+| `Enum.into(enum, %{})`                     | `Map.new(enum)`                     |
+| `Enum.into(enum, Map.new())`               | `Map.new(enum)`                     |
+| `Enum.into(enum, Keyword.new())`           | `Keyword.new(enum)`                 |
+| `Enum.into(enum, MapSet.new())`            | `Keyword.new(enum)`                 |
+| `Enum.into(enum, %{}, fn x -> {x, x} end)` | `Map.new(enum, fn x -> {x, x} end)` |
+| `Enum.into(enum, [])`                      | `Enum.to_list(enum)`                |
+| `Enum.into(enum, [], mapper)`              | `Enum.map(enum, mapper)`            |
 
 ## Map/Keyword.merge w/ single key literal -> X.put
 
@@ -81,6 +81,7 @@ map |> Map.put(:key, value) |> foo()
 ## Map/Keyword.drop w/ single key -> X.delete
 
 In the same vein as the `merge` style above, `[Map|Keyword].drop/2` with a single key to drop are rewritten to use `delete/2`
+
 ```elixir
 # Before
 Map.drop(map, [key])
@@ -177,12 +178,12 @@ after
 end
 ```
 
-## Remove parenthesis from 0-arity function & macro definitions
+## Remove or add parenthesis from 0-arity functions and macro definitions
 
-The author of the library disagrees with this style convention :) BUT, the wonderful thing about Styler is it lets you write code how _you_ want to, while normalizing it for reading for your entire team. The most important thing is not having to think about the style, and instead focus on what you're trying to achieve.
+If `zero_arity_parens` is `true` in the config, styler will add parens to 0-arity function & macro definitions. If `zero_arity_parens` is `false` in the config, styler will remove parens from 0-arity function & macro definitions. The default is `false`.
 
 ```elixir
-# Before
+# Before (zero_arity_parens: false)
 def foo()
 defp foo()
 defmacro foo()
@@ -195,22 +196,37 @@ defmacro foo
 defmacrop foo
 ```
 
+```elixir
+# Before (zero_arity_parens: true)
+def foo
+defp foo
+defmacro foo
+defmacrop foo
+
+# Styled
+def foo()
+defp foo()
+defmacro foo()
+defmacrop foo()
+```
+
 ## Elixir Deprecation Rewrites
 
 ### 1.15+
 
-| Before | After |
-|--------|-------|
-| `Logger.warn` | `Logger.warning`|
-| `Path.safe_relative_to/2` | `Path.safe_relative/2`|
-| `~R/my_regex/` | `~r/my_regex/`|
-| `Enum/String.slice/2` with decreasing ranges | add explicit steps to the range * |
-| `Date.range/2` with decreasing range | `Date.range/3` *|
-| `IO.read/bin_read` with `:all` option | replace `:all` with `:eof`|
+| Before                                       | After                              |
+| -------------------------------------------- | ---------------------------------- |
+| `Logger.warn`                                | `Logger.warning`                   |
+| `Path.safe_relative_to/2`                    | `Path.safe_relative/2`             |
+| `~R/my_regex/`                               | `~r/my_regex/`                     |
+| `Enum/String.slice/2` with decreasing ranges | add explicit steps to the range \* |
+| `Date.range/2` with decreasing range         | `Date.range/3` \*                  |
+| `IO.read/bin_read` with `:all` option        | replace `:all` with `:eof`         |
 
 \* For both of the "decreasing range" changes, the rewrite can only be applied if the range is being passed as an argument to the function.
 
 ### 1.16+
+
 File.stream! `:line` and `:bytes` deprecation
 
 ```elixir

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -178,26 +178,12 @@ after
 end
 ```
 
-## Remove or add parenthesis from 0-arity functions and macro definitions
+## Add parenthesis to 0-arity functions and macro definitions
 
-If `zero_arity_parens` is `true` in the config, styler will add parens to 0-arity function & macro definitions. If `zero_arity_parens` is `false` in the config, styler will remove parens from 0-arity function & macro definitions. The default is `false`.
-
-```elixir
-# Before (zero_arity_parens: false)
-def foo()
-defp foo()
-defmacro foo()
-defmacrop foo()
-
-# Styled
-def foo
-defp foo
-defmacro foo
-defmacrop foo
-```
+The styler will add parens to 0-arity function & macro definitions.
 
 ```elixir
-# Before (zero_arity_parens: true)
+# Before
 def foo
 defp foo
 defmacro foo

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -165,19 +165,9 @@ defmodule Styler.Style.SingleNode do
   defp style({def, dm, [head, [{_, {:try, _, [try_children]}}]]}) when def in ~w(def defp)a,
     do: style({def, dm, [head, try_children]})
 
-  # Remove parens from 0 arity funs (Credo.Check.Readability.ParenthesesOnZeroArityDefs)
-  defp style({def, dm, [{fun, funm, []} | rest]} = node) when def in ~w(def defp)a and is_atom(fun) do
-    if Styler.Config.zero_arity_parens?(),
-      do: node,
-      else: style({def, dm, [{fun, Keyword.delete(funm, :closing), nil} | rest]})
-  end
-
   # Add parens to 0 arity funs (Credo.Check.Readability.ParenthesesOnZeroArityDefs)
-  defp style({def, dm, [{fun, funm, nil} | rest]} = node) when def in ~w(def defp)a and is_atom(fun) do
-    if Styler.Config.zero_arity_parens?(),
-      do: {def, dm, [{fun, Keyword.put(funm, :closing, line: funm[:line]), []} | rest]},
-      else: node
-  end
+  defp style({def, dm, [{fun, funm, nil} | rest]}) when def in ~w(def defp)a and is_atom(fun),
+    do: {def, dm, [{fun, Keyword.put(funm, :closing, line: funm[:line]), []} | rest]}
 
   defp style({def, dm, [{fun, funm, params} | rest]}) when def in ~w(def defp)a,
     do: {def, dm, [{fun, funm, put_matches_on_right(params)} | rest]}

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -42,11 +42,8 @@ defmodule Styler.Config do
       end)
       |> MapSet.union(@stdlib)
 
-    zero_arity_parens = config[:zero_arity_parens]
-
     :persistent_term.put(@key, %{
-      lifting_excludes: excludes,
-      zero_arity_parens: zero_arity_parens
+      lifting_excludes: excludes
     })
   end
 
@@ -54,9 +51,5 @@ defmodule Styler.Config do
     @key
     |> :persistent_term.get()
     |> Map.fetch!(key)
-  end
-
-  def zero_arity_parens? do
-    get(:zero_arity_parens)
   end
 end

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -42,8 +42,11 @@ defmodule Styler.Config do
       end)
       |> MapSet.union(@stdlib)
 
+    zero_arity_parens = config[:zero_arity_parens]
+
     :persistent_term.put(@key, %{
-      lifting_excludes: excludes
+      lifting_excludes: excludes,
+      zero_arity_parens: zero_arity_parens
     })
   end
 
@@ -51,5 +54,9 @@ defmodule Styler.Config do
     @key
     |> :persistent_term.get()
     |> Map.fetch!(key)
+  end
+
+  def zero_arity_parens? do
+    get(:zero_arity_parens)
   end
 end

--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -317,7 +317,7 @@ defmodule Styler.Style.BlocksTest do
         end
         """,
         """
-        def run do
+        def run() do
           arg
         end
         """

--- a/test/style/defs_test.exs
+++ b/test/style/defs_test.exs
@@ -98,7 +98,7 @@ defmodule Styler.Style.DefsTest do
     end
 
     test "no body" do
-      assert_style "def no_body_nor_parens_yikes!"
+      assert_style "def no_body_nor_parens_yikes!()"
 
       assert_style(
         """
@@ -156,7 +156,7 @@ defmodule Styler.Style.DefsTest do
         """,
         """
         # Weirdo comment
-        def foo, do: [:never_write_code_like_this]
+        def foo(), do: [:never_write_code_like_this]
         """
       )
     end
@@ -164,7 +164,7 @@ defmodule Styler.Style.DefsTest do
     test "rewrites subsequent definitions" do
       assert_style(
         """
-        def foo(), do: :ok
+        def foo, do: :ok
 
         def foo(
           too,
@@ -173,7 +173,7 @@ defmodule Styler.Style.DefsTest do
         ), do: :ok
         """,
         """
-        def foo, do: :ok
+        def foo(), do: :ok
 
         # Long long is too long
         def foo(too, long), do: :ok
@@ -221,7 +221,7 @@ defmodule Styler.Style.DefsTest do
 
       @doc "this is another function"
       # And it also has a comment
-      def this_one_fits_on_one_line, do: :ok
+      def this_one_fits_on_one_line(), do: :ok
       """)
     end
 

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -31,7 +31,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
         alias A.B.C
 
         @spec bar :: C.t()
-        def bar do
+        def bar() do
           C.f()
         end
       end
@@ -118,7 +118,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
 
         require C
 
-        def foo do
+        def foo() do
           C.bop()
         end
       end
@@ -169,7 +169,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
         @moduledoc false
         alias A.B.C
 
-        def lift_me do
+        def lift_me() do
           C.foo()
           C.baz()
         end

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -16,7 +16,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
     test "handles module with no directives" do
       assert_style("""
       defmodule Test do
-        def foo, do: :ok
+        def foo(), do: :ok
       end
       """)
     end
@@ -240,7 +240,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
           def c(x), do: y
 
           @doc "d doc"
-          def d do
+          def d() do
             import Ecto.Query
 
             alias H.H
@@ -436,7 +436,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
           alias B.B
 
           # foo
-          def foo do
+          def foo() do
             # ok
             :ok
           end
@@ -456,7 +456,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
           alias C.C
 
           # foo
-          def foo do
+          def foo() do
             # ok
             :ok
           end
@@ -530,7 +530,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
         @derive {Foo, bar: :baz}
         defstruct [:a]
         # comment for foo
-        def foo, do: :ok
+        def foo(), do: :ok
       end
       """
     )

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -305,7 +305,7 @@ defmodule Styler.Style.PipesTest do
         end
         """,
         """
-        def foo do
+        def foo() do
           case_result =
             case x do
               x -> x
@@ -329,7 +329,7 @@ defmodule Styler.Style.PipesTest do
         end
         """,
         """
-        def foo do
+        def foo() do
           if_result =
             if true do
               nil
@@ -375,7 +375,7 @@ defmodule Styler.Style.PipesTest do
       assert_style("b(a) |> c()", "a |> b() |> c()")
       assert_style("a |> f()", "f(a)")
       assert_style("x |> bar", "bar(x)")
-      assert_style("def a, do: b |> c()", "def a, do: c(b)")
+      assert_style("def a, do: b |> c()", "def a(), do: c(b)")
     end
 
     test "keeps invocation on a single line" do
@@ -703,7 +703,7 @@ defmodule Styler.Style.PipesTest do
             end
             """,
             """
-            def foo do
+            def foo() do
               filename_map = Map.new(foo, &{&1.filename, true})
             end
             """

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -136,6 +136,13 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style("def metaprogramming(foo)(), do: bar")
     end
 
+    test "0-arity functions have parens when zero_arity_parens is enabled" do
+      Styler.Config.set!(zero_arity_parens: true)
+      assert_style("def foo, do: :ok", "def foo(), do: :ok")
+      assert_style("defp foo, do: :ok", "defp foo(), do: :ok")
+      Styler.Config.set!(zero_arity_parens: false)
+    end
+
     test "prefers implicit try" do
       for def_style <- ~w(def defp) do
         assert_style(

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -102,18 +102,18 @@ defmodule Styler.Style.SingleNodeTest do
   end
 
   describe "def / defp" do
-    test "0-arity functions have parens removed" do
-      assert_style("def foo(), do: :ok", "def foo, do: :ok")
-      assert_style("defp foo(), do: :ok", "defp foo, do: :ok")
+    test "0-arity functions have parens added" do
+      assert_style("def foo, do: :ok", "def foo(), do: :ok")
+      assert_style("defp foo, do: :ok", "defp foo(), do: :ok")
 
       assert_style(
         """
-        def foo() do
+        def foo do
         :ok
         end
         """,
         """
-        def foo do
+        def foo() do
           :ok
         end
         """
@@ -121,12 +121,12 @@ defmodule Styler.Style.SingleNodeTest do
 
       assert_style(
         """
-        defp foo() do
+        defp foo do
         :ok
         end
         """,
         """
-        defp foo do
+        defp foo() do
           :ok
         end
         """
@@ -134,13 +134,6 @@ defmodule Styler.Style.SingleNodeTest do
 
       # Regression: be wary of invocations with extra parens from metaprogramming
       assert_style("def metaprogramming(foo)(), do: bar")
-    end
-
-    test "0-arity functions have parens when zero_arity_parens is enabled" do
-      Styler.Config.set!(zero_arity_parens: true)
-      assert_style("def foo, do: :ok", "def foo(), do: :ok")
-      assert_style("defp foo, do: :ok", "defp foo(), do: :ok")
-      Styler.Config.set!(zero_arity_parens: false)
     end
 
     test "prefers implicit try" do
@@ -162,7 +155,7 @@ defmodule Styler.Style.SingleNodeTest do
           end
           """,
           """
-          #{def_style} foo do
+          #{def_style} foo() do
             :ok
           rescue
             exception -> :excepted
@@ -180,7 +173,7 @@ defmodule Styler.Style.SingleNodeTest do
 
     test "doesnt rewrite when there are other things in the body" do
       assert_style("""
-      def foo do
+      def foo() do
         try do
           :ok
         rescue

--- a/test/style/styles_test.exs
+++ b/test/style/styles_test.exs
@@ -20,14 +20,14 @@ defmodule Styler.Style.StylesTest do
         """
         foo
         |> bar(fn baz ->
-          def widget() do
+          def widget do
             :bop
           end
         end)
         """,
         """
         bar(foo, fn baz ->
-          def widget do
+          def widget() do
             :bop
           end
         end)


### PR DESCRIPTION
The original version of this repository removes parenthesis from 0-arity functions. However, in SmartRent repos, we enforce parenthesis for 0-arity functions.