### PR TITLE
Change line length to match credo setting

### DIFF
--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -92,7 +92,7 @@ defmodule Styler do
   # Turns an ast and comments back into code, formatting it along the way.
   def quoted_to_string(ast, comments, formatter_opts \\ []) do
     opts = [{:comments, comments}, {:escape, false} | formatter_opts]
-    {line_length, opts} = Keyword.pop(opts, :line_length, 122)
+    line_length = Styler.Config.line_length()
 
     formatted =
       ast

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -12,6 +12,7 @@ defmodule Styler.Config do
   @moduledoc false
 
   alias Credo.Check.Readability.AliasOrder
+  alias Credo.Check.Readability.MaxLineLength
 
   @key __MODULE__
 
@@ -49,6 +50,7 @@ defmodule Styler.Config do
 
     :persistent_term.put(@key, %{
       lifting_excludes: excludes,
+      line_length: credo_opts[:line_length] || 120,
       sort_order: credo_opts[:sort_order] || :alpha
     })
   end
@@ -66,6 +68,10 @@ defmodule Styler.Config do
 
   def sort_order do
     get(:sort_order)
+  end
+
+  def line_length do
+    get(:line_length)
   end
 
   defp read_credo_config do


### PR DESCRIPTION
The built-in line length limit is 122. We would prefer to set the line length based on a credo configuration.