### PR TITLE
Add config for code rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Styler can be configured in your `.formatter.exs` file
   plugins: [Styler],
   styler: [
     alias_lifting_exclude: [...],
+    rewrite_case_to_if: false,
+    reorder_configs: false,
     sort_order: :ascii | :alpha,
     zero_arity_parens: true
   ]
@@ -76,6 +78,8 @@ Styler can be configured in your `.formatter.exs` file
 Styler has several configuration options:
 
 - `:alias_lifting_exclude`, which accepts a list of atoms to _not_ lift. See the [Module Directive documentation](docs/module_directives.md#alias-lifting) for more.
+- `:rewrite_case_to_if`, which controls whether or not to rewrite `case` statements to `if` statements. Defaults to true.
+- `:reorder_configs`, which controls whether or not to reorder `config` statements. Defaults to true.
 - `:sort_order`, which controls the sorting order of module directives. Defaults to `:alpha`.
 - `:zero_arity_parens`, which controls whether or not zero-arity functions should have parens. Defaults to false. See the [Single Node documentation](docs/styles.md#remove-or-add-parenthesis-from-0-arity-functions-and-macro-definitions) for more.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can learn more about the history, purpose and implementation of Styler from 
 
 ## Who is Styler for?
 
-Styler was designed for a **large team (40+ engineers) working in a single codebase. It helps remove fiddly code review comments and removes failed linter CI slowdowns, helping teams get things done faster. Teams in similar situations might appreciate Styler.
+Styler was designed for a \*\*large team (40+ engineers) working in a single codebase. It helps remove fiddly code review comments and removes failed linter CI slowdowns, helping teams get things done faster. Teams in similar situations might appreciate Styler.
 
 Its automations are also extremely valuable for taming legacy elixir codebases or just refactoring in general. Some of its rewrites have inspired code actions in elixir language servers.
 
@@ -66,18 +66,16 @@ Styler can be configured in your `.formatter.exs` file
 [
   plugins: [Styler],
   styler: [
-    alias_lifting_exclude: [...]
+    alias_lifting_exclude: [...],
+    zero_arity_parens: true
   ]
 ]
 ```
 
-Styler's only current configuration option is `:alias_lifting_exclude`, which accepts a list of atoms to _not_ lift. See the [Module Directive documentation](docs/module_directives.md#alias-lifting) for more.
+Styler has two configuration options:
 
-#### No Credo-Style Enable/Disable
-
-Styler [will not add configuration](https://github.com/adobe/elixir-styler/pull/127#issuecomment-1912242143) for ad-hoc enabling/disabling of rewrites. Sorry! Its implementation simply does not support that approach. There are however many forks out there that have attempted this; please explore the [Github forks tab](https://github.com/adobe/elixir-styler/forks) to see if there's a project that suits your needs or that you can draw inspiration from.
-
-Ultimately Styler is @adobe's internal tool that we're happy to share with the world. We're delighted if you like it as is, and just as excited if it's a starting point for you to make something even better for yourself.
+- `:alias_lifting_exclude`, which accepts a list of atoms to _not_ lift. See the [Module Directive documentation](docs/module_directives.md#alias-lifting) for more.
+- `:zero_arity_parens`, which controls whether or not zero-arity functions should have parens. Defaults to false. See the [Single Node documentation](docs/styles.md#remove-or-add-parenthesis-from-0-arity-functions-and-macro-definitions) for more.
 
 ## WARNING: Styler can change the behaviour of your program!
 

--- a/README.md
+++ b/README.md
@@ -67,14 +67,16 @@ Styler can be configured in your `.formatter.exs` file
   plugins: [Styler],
   styler: [
     alias_lifting_exclude: [...],
+    sort_order: :ascii | :alpha,
     zero_arity_parens: true
   ]
 ]
 ```
 
-Styler has two configuration options:
+Styler has several configuration options:
 
 - `:alias_lifting_exclude`, which accepts a list of atoms to _not_ lift. See the [Module Directive documentation](docs/module_directives.md#alias-lifting) for more.
+- `:sort_order`, which controls the sorting order of module directives. Defaults to `:alpha`.
 - `:zero_arity_parens`, which controls whether or not zero-arity functions should have parens. Defaults to false. See the [Single Node documentation](docs/styles.md#remove-or-add-parenthesis-from-0-arity-functions-and-macro-definitions) for more.
 
 ## WARNING: Styler can change the behaviour of your program!

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -25,14 +25,14 @@ Formatter already does this except it doesn't rewrite "typos" like `100_000_0`.
 If you're concerned that this breaks your team's formatting for things like "cents" (like "$100" being written as `100_00`),
 consider using a library made for denoting currencies rather than raw elixir integers.
 
-| Before | After |
-|--------|-------|
-| `10000 ` | `10_000`|
-| `1_0_0_0_0` | `10_000` (elixir's formatter leaves the former as-is)|
-| `-543213 ` | `-543_213`|
-| `123456789 ` | `123_456_789`|
-| `55333.22 ` | `55_333.22`|
-| `-123456728.0001 ` | `-123_456_728.0001`|
+| Before             | After                                                 |
+| ------------------ | ----------------------------------------------------- |
+| `10000 `           | `10_000`                                              |
+| `1_0_0_0_0`        | `10_000` (elixir's formatter leaves the former as-is) |
+| `-543213 `         | `-543_213`                                            |
+| `123456789 `       | `123_456_789`                                         |
+| `55333.22 `        | `55_333.22`                                           |
+| `-123456728.0001 ` | `-123_456_728.0001`                                   |
 
 ## `Enum.into` -> `X.new`
 
@@ -42,15 +42,15 @@ This is an improvement for the reader, who gets a more natural language expressi
 
 Note that all of the examples below also apply to pipes (`enum |> Enum.into(...)`)
 
-| Before | After |
-|--------|-------|
-| `Enum.into(enum, %{})` | `Map.new(enum)`|
-| `Enum.into(enum, Map.new())` | `Map.new(enum)`|
-| `Enum.into(enum, Keyword.new())` | `Keyword.new(enum)`|
-| `Enum.into(enum, MapSet.new())` | `Keyword.new(enum)`|
-| `Enum.into(enum, %{}, fn x -> {x, x} end)` | `Map.new(enum, fn x -> {x, x} end)`|
-| `Enum.into(enum, [])` | `Enum.to_list(enum)` |
-| `Enum.into(enum, [], mapper)` | `Enum.map(enum, mapper)`|
+| Before                                     | After                               |
+| ------------------------------------------ | ----------------------------------- |
+| `Enum.into(enum, %{})`                     | `Map.new(enum)`                     |
+| `Enum.into(enum, Map.new())`               | `Map.new(enum)`                     |
+| `Enum.into(enum, Keyword.new())`           | `Keyword.new(enum)`                 |
+| `Enum.into(enum, MapSet.new())`            | `Keyword.new(enum)`                 |
+| `Enum.into(enum, %{}, fn x -> {x, x} end)` | `Map.new(enum, fn x -> {x, x} end)` |
+| `Enum.into(enum, [])`                      | `Enum.to_list(enum)`                |
+| `Enum.into(enum, [], mapper)`              | `Enum.map(enum, mapper)`            |
 
 ## Map/Keyword.merge w/ single key literal -> X.put
 
@@ -81,6 +81,7 @@ map |> Map.put(:key, value) |> foo()
 ## Map/Keyword.drop w/ single key -> X.delete
 
 In the same vein as the `merge` style above, `[Map|Keyword].drop/2` with a single key to drop are rewritten to use `delete/2`
+
 ```elixir
 # Before
 Map.drop(map, [key])
@@ -177,12 +178,12 @@ after
 end
 ```
 
-## Remove parenthesis from 0-arity function & macro definitions
+## Remove or add parenthesis from 0-arity functions and macro definitions
 
-The author of the library disagrees with this style convention :) BUT, the wonderful thing about Styler is it lets you write code how _you_ want to, while normalizing it for reading for your entire team. The most important thing is not having to think about the style, and instead focus on what you're trying to achieve.
+If `zero_arity_parens` is `true` in the config, styler will add parens to 0-arity function & macro definitions. If `zero_arity_parens` is `false` in the config, styler will remove parens from 0-arity function & macro definitions. The default is `false`.
 
 ```elixir
-# Before
+# Before (zero_arity_parens: false)
 def foo()
 defp foo()
 defmacro foo()
@@ -195,22 +196,37 @@ defmacro foo
 defmacrop foo
 ```
 
+```elixir
+# Before (zero_arity_parens: true)
+def foo
+defp foo
+defmacro foo
+defmacrop foo
+
+# Styled
+def foo()
+defp foo()
+defmacro foo()
+defmacrop foo()
+```
+
 ## Elixir Deprecation Rewrites
 
 ### 1.15+
 
-| Before | After |
-|--------|-------|
-| `Logger.warn` | `Logger.warning`|
-| `Path.safe_relative_to/2` | `Path.safe_relative/2`|
-| `~R/my_regex/` | `~r/my_regex/`|
-| `Enum/String.slice/2` with decreasing ranges | add explicit steps to the range * |
-| `Date.range/2` with decreasing range | `Date.range/3` *|
-| `IO.read/bin_read` with `:all` option | replace `:all` with `:eof`|
+| Before                                       | After                              |
+| -------------------------------------------- | ---------------------------------- |
+| `Logger.warn`                                | `Logger.warning`                   |
+| `Path.safe_relative_to/2`                    | `Path.safe_relative/2`             |
+| `~R/my_regex/`                               | `~r/my_regex/`                     |
+| `Enum/String.slice/2` with decreasing ranges | add explicit steps to the range \* |
+| `Date.range/2` with decreasing range         | `Date.range/3` \*                  |
+| `IO.read/bin_read` with `:all` option        | replace `:all` with `:eof`         |
 
 \* For both of the "decreasing range" changes, the rewrite can only be applied if the range is being passed as an argument to the function.
 
 ### 1.16+
+
 File.stream! `:line` and `:bytes` deprecation
 
 ```elixir

--- a/lib/style/blocks.ex
+++ b/lib/style/blocks.ex
@@ -35,7 +35,7 @@ defmodule Styler.Style.Blocks do
   # case statement with exactly 2 `->` cases
   # rewrite to `if` if it's any of 3 trivial cases
   def run({{:case, _, [head, [{_, [{:->, _, [[lhs_a], a]}, {:->, _, [[lhs_b], b]}]}]]}, _} = zipper, ctx) do
-    case {lhs_a, lhs_b} do
+    case Styler.Config.rewrite_case_to_if?() && {lhs_a, lhs_b} do
       {{_, _, [true]}, {_, _, [false]}} -> if_ast(zipper, head, a, b, ctx)
       {{_, _, [true]}, {:_, _, _}} -> if_ast(zipper, head, a, b, ctx)
       {{_, _, [false]}, {_, _, [true]}} -> if_ast(zipper, head, b, a, ctx)

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -411,9 +411,15 @@ defmodule Styler.Style.ModuleDirectives do
   defp expand(other), do: [other]
 
   defp sort(directives) do
-    # sorting is done with `downcase` to match Credo
-    directives
-    |> Enum.map(&{&1, &1 |> Macro.to_string() |> String.downcase()})
+    directive_strings =
+      if Styler.Config.sort_order() == :ascii do
+        Enum.map(directives, &{&1, Macro.to_string(&1)})
+      else
+        # sorting is done with `downcase` to match Credo
+        Enum.map(directives, &{&1, &1 |> Macro.to_string() |> String.downcase()})
+      end
+
+    directive_strings
     |> Enum.uniq_by(&elem(&1, 1))
     |> List.keysort(1)
     |> Enum.map(&elem(&1, 0))

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -92,7 +92,7 @@ defmodule Styler do
   # Turns an ast and comments back into code, formatting it along the way.
   def quoted_to_string(ast, comments, formatter_opts \\ []) do
     opts = [{:comments, comments}, {:escape, false} | formatter_opts]
-    {line_length, opts} = Keyword.pop(opts, :line_length, 122)
+    {line_length, opts} = Keyword.pop(opts, :line_length, 120)
 
     formatted =
       ast

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -18,16 +18,6 @@ defmodule Styler do
   alias Styler.StyleError
   alias Styler.Zipper
 
-  @styles [
-    Styler.Style.ModuleDirectives,
-    Styler.Style.Pipes,
-    Styler.Style.SingleNode,
-    Styler.Style.Defs,
-    Styler.Style.Blocks,
-    Styler.Style.Deprecations,
-    Styler.Style.Configs
-  ]
-
   @doc false
   def style({ast, comments}, file, opts) do
     on_error = opts[:on_error] || :log
@@ -35,7 +25,7 @@ defmodule Styler do
     zipper = Zipper.zip(ast)
 
     {{ast, _}, comments} =
-      Enum.reduce(@styles, {zipper, comments}, fn style, {zipper, comments} ->
+      Enum.reduce(Styler.Config.get_styles(), {zipper, comments}, fn style, {zipper, comments} ->
         context = %{comments: comments, file: file}
 
         try do

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -43,9 +43,11 @@ defmodule Styler.Config do
       |> MapSet.union(@stdlib)
 
     zero_arity_parens = config[:zero_arity_parens]
+    sort_order = config[:sort_order] || :alpha
 
     :persistent_term.put(@key, %{
       lifting_excludes: excludes,
+      sort_order: sort_order,
       zero_arity_parens: zero_arity_parens
     })
   end
@@ -58,5 +60,9 @@ defmodule Styler.Config do
 
   def zero_arity_parens? do
     get(:zero_arity_parens)
+  end
+
+  def sort_order do
+    get(:sort_order)
   end
 end

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -42,8 +42,11 @@ defmodule Styler.Config do
       end)
       |> MapSet.union(@stdlib)
 
+    zero_arity_parens = config[:zero_arity_parens]
+
     :persistent_term.put(@key, %{
-      lifting_excludes: excludes
+      lifting_excludes: excludes,
+      zero_arity_parens: zero_arity_parens
     })
   end
 
@@ -51,5 +54,9 @@ defmodule Styler.Config do
     @key
     |> :persistent_term.get()
     |> Map.fetch!(key)
+  end
+
+  def zero_arity_parens? do
+    get(:zero_arity_parens)
   end
 end

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -19,6 +19,16 @@ defmodule Styler.Config do
     Range Record Regex Registry Set Stream String StringIO Supervisor System Task Time Tuple URI Version
   )a)
 
+  @styles [
+    Styler.Style.ModuleDirectives,
+    Styler.Style.Pipes,
+    Styler.Style.SingleNode,
+    Styler.Style.Defs,
+    Styler.Style.Blocks,
+    Styler.Style.Deprecations,
+    Styler.Style.Configs
+  ]
+
   def set(config) do
     :persistent_term.get(@key)
     :ok
@@ -44,9 +54,13 @@ defmodule Styler.Config do
 
     zero_arity_parens = config[:zero_arity_parens]
     sort_order = config[:sort_order] || :alpha
+    rewrite_case_to_if = if is_nil(config[:rewrite_case_to_if]), do: true, else: config[:rewrite_case_to_if]
+    reorder_configs = if is_nil(config[:reorder_configs]), do: true, else: config[:reorder_configs]
 
     :persistent_term.put(@key, %{
+      rewrite_case_to_if: rewrite_case_to_if,
       lifting_excludes: excludes,
+      reorder_configs: reorder_configs,
       sort_order: sort_order,
       zero_arity_parens: zero_arity_parens
     })
@@ -65,4 +79,15 @@ defmodule Styler.Config do
   def sort_order do
     get(:sort_order)
   end
+
+  def rewrite_case_to_if? do
+    get(:rewrite_case_to_if)
+  end
+
+  def get_styles do
+    maybe_exclude(@styles, Styler.Style.Configs, get(:reorder_configs))
+  end
+
+  defp maybe_exclude(list, _elem, true), do: list
+  defp maybe_exclude(list, elem, false), do: list -- [elem]
 end

--- a/test/style/configs_test.exs
+++ b/test/style/configs_test.exs
@@ -14,6 +14,8 @@ defmodule Styler.Style.ConfigsTest do
 
   alias Styler.Style.Configs
 
+  require Logger
+
   test "only runs on exs files in config folders" do
     {ast, _} = Styler.string_to_quoted_with_comments("import Config\n\nconfig :bar, boop: :baz")
     zipper = Styler.Zipper.zip(ast)
@@ -172,6 +174,26 @@ defmodule Styler.Style.ConfigsTest do
         config :b, 2
         """
       )
+    end
+
+    test "does not reorder simple case if rewrite_if_to_unless is false" do
+      Styler.Config.set!(reorder_configs: false)
+      assert_style(
+        """
+        import Config
+
+        config :a, 1
+        config :a, 4
+        # comment
+        # b comment
+        config :b, 1
+        config :b, 2
+        config :a, 2
+        config :a, 3
+        """
+      )
+
+      Styler.Config.set!(reorder_configs: true)
     end
 
     test "complicated comments" do

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -202,6 +202,66 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
     )
   end
 
+  test "sorts in alpha order when sort_order is :alpha" do
+    assert_style(
+      """
+      defmodule A do
+        alias A.SPOOL
+        alias A.School
+        alias A.Stool
+
+        SPOOL.foo()
+        School.foo()
+        Stool.foo()
+      end
+      """,
+      """
+      defmodule A do
+        @moduledoc false
+        alias A.School
+        alias A.SPOOL
+        alias A.Stool
+
+        SPOOL.foo()
+        School.foo()
+        Stool.foo()
+      end
+      """
+    )
+  end
+
+  test "sorts in ascii order when sort_order is :ascii" do
+    Styler.Config.set!(sort_order: :ascii)
+
+    assert_style(
+      """
+      defmodule A do
+        alias A.SPOOL
+        alias A.School
+        alias A.Stool
+
+        SPOOL.foo()
+        School.foo()
+        Stool.foo()
+      end
+      """,
+      """
+      defmodule A do
+        @moduledoc false
+        alias A.SPOOL
+        alias A.School
+        alias A.Stool
+
+        SPOOL.foo()
+        School.foo()
+        Stool.foo()
+      end
+      """
+    )
+
+    Styler.Config.set!(sort_order: :alpha)
+  end
+
   describe "comments stay put" do
     test "comments before alias stanza" do
       assert_style(

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -136,6 +136,13 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style("def metaprogramming(foo)(), do: bar")
     end
 
+    test "0-arity functions have parens when zero_arity_parens is enabled" do
+      Styler.Config.set!(zero_arity_parens: true)
+      assert_style("def foo, do: :ok", "def foo(), do: :ok")
+      assert_style("defp foo, do: :ok", "defp foo(), do: :ok")
+      Styler.Config.set!(zero_arity_parens: false)
+    end
+
     test "prefers implicit try" do
       for def_style <- ~w(def defp) do
         assert_style(


### PR DESCRIPTION
Allow users to disable rewriting `case` to `if` since it can change behavior in very rare cases. The config is `include_case_to_if`. Also allow users to disable reordering config files since it can change behavior.

There is a very rare `with` rewrite that could change behavior ([see issue](https://github.com/adobe/elixir-styler/issues/186)), but it is so unlikely that I'm deeming it not worth spending time on.