### PR TITLE
Add config to not use unless

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ Styler can be configured in your `.formatter.exs` file
   plugins: [Styler],
   styler: [
     alias_lifting_exclude: [...],
-    rewrite_case_to_if: false,
     reorder_configs: false,
+rewrite_case_to_if: false,
+    rewrite_if_to_unless: true | false,
     sort_order: :ascii | :alpha,
-    zero_arity_parens: true
+    zero_arity_parens: true | false
   ]
 ]
 ```
@@ -78,8 +79,9 @@ Styler can be configured in your `.formatter.exs` file
 Styler has several configuration options:
 
 - `:alias_lifting_exclude`, which accepts a list of atoms to _not_ lift. See the [Module Directive documentation](docs/module_directives.md#alias-lifting) for more.
-- `:rewrite_case_to_if`, which controls whether or not to rewrite `case` statements to `if` statements. Defaults to true.
 - `:reorder_configs`, which controls whether or not to reorder `config` statements. Defaults to true.
+- `:rewrite_case_to_if`, which controls whether or not to rewrite `case` statements to `if` statements. Defaults to true.
+- `:rewrite_if_to_unless`, which controls whether or not to rewrite `if` statements to `unless` statements. Defaults to true.
 - `:sort_order`, which controls the sorting order of module directives. Defaults to `:alpha`.
 - `:zero_arity_parens`, which controls whether or not zero-arity functions should have parens. Defaults to false. See the [Single Node documentation](docs/styles.md#remove-or-add-parenthesis-from-0-arity-functions-and-macro-definitions) for more.
 

--- a/lib/style/blocks.ex
+++ b/lib/style/blocks.ex
@@ -197,9 +197,13 @@ defmodule Styler.Style.Blocks do
       [negator, [{do_, do_body}, {else_, else_body}]] when is_negator(negator) ->
         zipper |> Zipper.replace({:if, m, [invert(negator), [{do_, else_body}, {else_, do_body}]]}) |> run(ctx)
 
-      # if not x, do: y => unless x, do: y
+      # if not x, do: y => unless x, do: y when rewrite_if_to_unless is true
       [negator, [do_block]] when is_negator(negator) ->
-        zipper |> Zipper.replace({:unless, m, [invert(negator), [do_block]]}) |> run(ctx)
+        if Styler.Config.rewrite_if_to_unless?() do
+          zipper |> Zipper.replace({:unless, m, [invert(negator), [do_block]]}) |> run(ctx)
+        else
+          {:cont, zipper, ctx}
+        end
 
       # drop `else: nil`
       [head, [do_block, {_, {:__block__, _, [nil]}}]] ->

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -54,13 +54,15 @@ defmodule Styler.Config do
 
     zero_arity_parens = config[:zero_arity_parens]
     sort_order = config[:sort_order] || :alpha
-    rewrite_case_to_if = if is_nil(config[:rewrite_case_to_if]), do: true, else: config[:rewrite_case_to_if]
     reorder_configs = if is_nil(config[:reorder_configs]), do: true, else: config[:reorder_configs]
+    rewrite_case_to_if = if is_nil(config[:rewrite_case_to_if]), do: true, else: config[:rewrite_case_to_if]
+    rewrite_if_to_unless = config[:rewrite_if_to_unless] || false
 
     :persistent_term.put(@key, %{
       rewrite_case_to_if: rewrite_case_to_if,
       lifting_excludes: excludes,
       reorder_configs: reorder_configs,
+      rewrite_if_to_unless: rewrite_if_to_unless,
       sort_order: sort_order,
       zero_arity_parens: zero_arity_parens
     })
@@ -82,6 +84,10 @@ defmodule Styler.Config do
 
   def rewrite_case_to_if? do
     get(:rewrite_case_to_if)
+  end
+
+  def rewrite_if_to_unless? do
+    get(:rewrite_if_to_unless)
   end
 
   def get_styles do

--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -833,10 +833,18 @@ defmodule Styler.Style.BlocksTest do
       """)
     end
 
-    test "if not => unless" do
+    test "if not => unless when rewrite_if_to_unless is true" do
+      Styler.Config.set!(rewrite_if_to_unless: true)
       assert_style("if not x, do: y", "unless x, do: y")
       assert_style("if !x, do: y", "unless x, do: y")
       assert_style("if !!x, do: y", "if x, do: y")
+      Styler.Config.set!(rewrite_if_to_unless: false)
+    end
+
+    test "if not => unless when rewrite_if_to_unless is false" do
+      assert_style("if not x, do: y")
+      assert_style("if !x, do: y")
+      assert_style("if !!x, do: y")
     end
 
     test "Credo.Check.Refactor.UnlessWithElse" do
@@ -1011,7 +1019,9 @@ defmodule Styler.Style.BlocksTest do
         """
       )
 
+      Styler.Config.set!(rewrite_if_to_unless: true)
       assert_style("if not (a != b), do: c", "if a == b, do: c")
+      Styler.Config.set!(rewrite_if_to_unless: false)
     end
 
     test "comments and flips" do


### PR DESCRIPTION
Some developers prefer to avoid `unless`. This adds a config option to not rewrite `if not a, do: b, else: c` to `unless a, do: c, else: b`. 