### PR TITLE
Use credo config to determine 0-arity parens setting

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -180,9 +180,10 @@ end
 
 ## Add parenthesis to 0-arity functions and macro definitions
 
-The styler will add parens to 0-arity function & macro definitions.
+The styler will, by default, add parens to 0-arity function & macro definitions. However, if .credo.exs has `Credo.Check.Readability.ParenthesesOnZeroArityDefs, parens: false`, the styler will remove zero-arity parens. Note that this is the opposite of the default behavior of Credo, which warns on 0-arity functions and macros with parentheses if `parens: true` is not set.
 
 ```elixir
+# Default behavior
 # Before
 def foo
 defp foo
@@ -194,6 +195,21 @@ def foo()
 defp foo()
 defmacro foo()
 defmacrop foo()
+```
+
+```elixir
+# Behavior if .credo.exs has `Credo.Check.Readability.ParenthesesOnZeroArityDefs, parens: false`
+# Before
+def foo()
+defp foo()
+defmacro foo()
+defmacrop foo()
+
+# Styled
+def foo
+defp foo
+defmacro foo
+defmacrop foo
 ```
 
 ## Elixir Deprecation Rewrites

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -165,9 +165,19 @@ defmodule Styler.Style.SingleNode do
   defp style({def, dm, [head, [{_, {:try, _, [try_children]}}]]}) when def in ~w(def defp)a,
     do: style({def, dm, [head, try_children]})
 
+  # Remove parens from 0 arity funs (Credo.Check.Readability.ParenthesesOnZeroArityDefs)
+  defp style({def, dm, [{fun, funm, []} | rest]} = node) when def in ~w(def defp)a and is_atom(fun) do
+    if Styler.Config.zero_arity_parens?(),
+      do: node,
+      else: style({def, dm, [{fun, Keyword.delete(funm, :closing), nil} | rest]})
+  end
+
   # Add parens to 0 arity funs (Credo.Check.Readability.ParenthesesOnZeroArityDefs)
-  defp style({def, dm, [{fun, funm, nil} | rest]}) when def in ~w(def defp)a and is_atom(fun),
-    do: {def, dm, [{fun, Keyword.put(funm, :closing, line: funm[:line]), []} | rest]}
+  defp style({def, dm, [{fun, funm, nil} | rest]} = node) when def in ~w(def defp)a and is_atom(fun) do
+    if Styler.Config.zero_arity_parens?(),
+      do: {def, dm, [{fun, Keyword.put(funm, :closing, line: funm[:line]), []} | rest]},
+      else: node
+  end
 
   defp style({def, dm, [{fun, funm, params} | rest]}) when def in ~w(def defp)a,
     do: {def, dm, [{fun, funm, put_matches_on_right(params)} | rest]}

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -13,6 +13,7 @@ defmodule Styler.Config do
 
   alias Credo.Check.Readability.AliasOrder
   alias Credo.Check.Readability.MaxLineLength
+  alias Credo.Check.Readability.ParenthesesOnZeroArityDefs
 
   @key __MODULE__
 
@@ -51,7 +52,8 @@ defmodule Styler.Config do
     :persistent_term.put(@key, %{
       lifting_excludes: excludes,
       line_length: credo_opts[:line_length] || 120,
-      sort_order: credo_opts[:sort_order] || :alpha
+      sort_order: credo_opts[:sort_order] || :alpha,
+      zero_arity_parens: credo_opts[:zero_arity_parens] || true
     })
   end
 
@@ -74,6 +76,10 @@ defmodule Styler.Config do
     get(:line_length)
   end
 
+  def zero_arity_parens? do
+    get(:zero_arity_parens)
+  end
+
   defp read_credo_config do
     exec = Credo.Execution.build()
     dir = File.cwd!()
@@ -88,6 +94,9 @@ defmodule Styler.Config do
 
       {MaxLineLength, opts}, acc when is_list(opts) ->
         Map.put(acc, :line_length, opts[:max_length])
+
+      {ParenthesesOnZeroArityDefs, opts}, acc when is_list(opts) ->
+        Map.put(acc, :zero_arity_parens, opts[:parens])
 
       _, acc ->
         acc

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -136,6 +136,44 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style("def metaprogramming(foo)(), do: bar")
     end
 
+    test "0-arity functions have parens removed when Styler.Config.zero_arity_parens? is false" do
+      Styler.Config.set_for_test!(:zero_arity_parens, false)
+
+      assert_style("def foo(), do: :ok", "def foo, do: :ok")
+      assert_style("defp foo(), do: :ok", "defp foo, do: :ok")
+
+      assert_style(
+        """
+        def foo() do
+        :ok
+        end
+        """,
+        """
+        def foo do
+          :ok
+        end
+        """
+      )
+
+      assert_style(
+        """
+        defp foo() do
+        :ok
+        end
+        """,
+        """
+        defp foo do
+          :ok
+        end
+        """
+      )
+
+      # Regression: be wary of invocations with extra parens from metaprogramming
+      assert_style("def metaprogramming(foo)(), do: bar")
+
+      Styler.Config.set_for_test!(:zero_arity_parens, true)
+    end
+
     test "prefers implicit try" do
       for def_style <- ~w(def defp) do
         assert_style(


### PR DESCRIPTION
Previously, we were always adding parenthesis to 0-arity functions. Instead, we should look at the credo config to determine the behavior. The default behavior is to add 0-arity parenthesis. Note that this default is different than the credo default, which is to assume there should *not* be parens for 0-arity.