### PR TITLE
Alphabetize config files based on config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,16 @@ Styler can be configured in your `.formatter.exs` file
 [
   plugins: [Styler],
   styler: [
-    alias_lifting_exclude: [...]
+    alias_lifting_exclude: [...],
+    reorder_configs: true | false
   ]
 ]
 ```
 
 Styler has several configuration options:
 
-- `:alias_lifting_exclude`, which accepts a list of atoms to _not_ lift. See the [Module Directive documentation](docs/module_directives.md#alias-lifting) for more.
+- `:alias_lifting_exclude`, which accepts a list of atoms to _not_ lift. See the [Module Directive documentation](docs/module_directives.md#alias-lifting) for more
+- `:reorder_configs`, which controls whether or not the configs in your `config/*.exs` files are alphabetized. This is true by default.
 
 ## WARNING: Styler can change the behaviour of your program!
 

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -18,16 +18,6 @@ defmodule Styler do
   alias Styler.StyleError
   alias Styler.Zipper
 
-  @styles [
-    Styler.Style.ModuleDirectives,
-    Styler.Style.Pipes,
-    Styler.Style.SingleNode,
-    Styler.Style.Defs,
-    Styler.Style.Blocks,
-    Styler.Style.Deprecations,
-    Styler.Style.Configs
-  ]
-
   @doc false
   def style({ast, comments}, file, opts) do
     on_error = opts[:on_error] || :log
@@ -35,7 +25,7 @@ defmodule Styler do
     zipper = Zipper.zip(ast)
 
     {{ast, _}, comments} =
-      Enum.reduce(@styles, {zipper, comments}, fn style, {zipper, comments} ->
+      Enum.reduce(Styler.Config.get_styles(), {zipper, comments}, fn style, {zipper, comments} ->
         context = %{comments: comments, file: file}
 
         try do

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -17,6 +17,16 @@ defmodule Styler.Config do
 
   @key __MODULE__
 
+  @styles [
+    Styler.Style.ModuleDirectives,
+    Styler.Style.Pipes,
+    Styler.Style.SingleNode,
+    Styler.Style.Defs,
+    Styler.Style.Blocks,
+    Styler.Style.Deprecations,
+    Styler.Style.Configs
+  ]
+
   @stdlib MapSet.new(~w(
     Access Agent Application Atom Base Behaviour Bitwise Code Date DateTime Dict Ecto Enum Exception
     File Float GenEvent GenServer HashDict HashSet Integer IO Kernel Keyword List
@@ -49,9 +59,12 @@ defmodule Styler.Config do
       end)
       |> MapSet.union(@stdlib)
 
+    reorder_configs = if is_nil(config[:reorder_configs]), do: true, else: config[:reorder_configs]
+
     :persistent_term.put(@key, %{
       lifting_excludes: excludes,
       line_length: credo_opts[:line_length] || 120,
+      reorder_configs: reorder_configs,
       sort_order: credo_opts[:sort_order] || :alpha,
       zero_arity_parens: credo_opts[:zero_arity_parens] || true
     })
@@ -66,6 +79,14 @@ defmodule Styler.Config do
     @key
     |> :persistent_term.get()
     |> Map.fetch!(key)
+  end
+
+  def get_styles do
+    if get(:reorder_configs) == true do
+      @styles
+    else
+      @styles -- [Styler.Style.Configs]
+    end
   end
 
   def sort_order do


### PR DESCRIPTION
Some may not want to alphabetize config files, since this can change behavior. Add an option to disable alphabetizing the config files.