### PR TITLE
Skip module directive refactor if specified in comment

### DIFF
--- a/docs/module_directives.md
+++ b/docs/module_directives.md
@@ -1,3 +1,13 @@
+## Skipping Module Reordering
+
+If you want to skip module reordering, you can add the following comment to the top of the file:
+
+```elixir
+# elixir-styler:skip-module-reordering
+```
+
+This will prevent Styler from doing any of the below transformations.
+
 ## Directive Expansion
 
 Expands `Module.{SubmoduleA, SubmoduleB}` to their explicit forms for ease of searching.

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -14,6 +14,7 @@ defmodule Styler.Config do
   alias Credo.Check.Readability.AliasOrder
   alias Credo.Check.Readability.MaxLineLength
   alias Credo.Check.Readability.ParenthesesOnZeroArityDefs
+  alias Styler.Style.Configs
 
   @key __MODULE__
 
@@ -24,7 +25,7 @@ defmodule Styler.Config do
     Styler.Style.Defs,
     Styler.Style.Blocks,
     Styler.Style.Deprecations,
-    Styler.Style.Configs
+    Configs
   ]
 
   @stdlib MapSet.new(~w(
@@ -81,34 +82,34 @@ defmodule Styler.Config do
     |> Map.fetch!(key)
   end
 
-  def get_styles do
+  def get_styles() do
     if get(:reorder_configs) == true do
       @styles
     else
-      @styles -- [Styler.Style.Configs]
+      @styles -- [Configs]
     end
   end
 
-  def sort_order do
+  def sort_order() do
     get(:sort_order)
   end
 
-  def line_length do
+  def line_length() do
     get(:line_length)
   end
 
-  def zero_arity_parens? do
+  def zero_arity_parens?() do
     get(:zero_arity_parens)
   end
 
-  defp read_credo_config do
+  defp read_credo_config() do
     exec = Credo.Execution.build()
     dir = File.cwd!()
     {:ok, config} = Credo.ConfigFile.read_or_default(exec, dir)
     config
   end
 
-  defp extract_configs_from_credo do
+  defp extract_configs_from_credo() do
     Enum.reduce(read_credo_config().checks, %{}, fn
       {AliasOrder, opts}, acc when is_list(opts) ->
         Map.put(acc, :sort_order, opts[:sort_method])

--- a/lib/zipper.ex
+++ b/lib/zipper.ex
@@ -164,7 +164,9 @@ defmodule Styler.Zipper do
   @spec remove(zipper) :: zipper
   def remove({_, nil}), do: raise(ArgumentError, message: "Cannot remove the top level node.")
   def remove({_, %{l: [left | rest]} = meta}), do: prev_down({left, %{meta | l: rest}})
-  def remove({_, %{ptree: {parent, parent_meta}, r: children}}), do: {do_replace_children(parent, children), parent_meta}
+
+  def remove({_, %{ptree: {parent, parent_meta}, r: children}}),
+    do: {do_replace_children(parent, children), parent_meta}
 
   @doc """
   Inserts the item as the left sibling of the node at this zipper, without

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Styler.MixProject do
   @version "1.1.1"
   @url "https://github.com/adobe/elixir-styler"
 
-  def project do
+  def project() do
     [
       app: :styler,
       version: @version,
@@ -37,16 +37,16 @@ defmodule Styler.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
-  def application, do: [extra_applications: [:logger]]
+  def application(), do: [extra_applications: [:logger]]
 
-  defp deps do
+  defp deps() do
     [
       {:ex_doc, "~> 0.31", runtime: false, only: :dev},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false}
     ]
   end
 
-  defp package do
+  defp package() do
     [
       maintainers: ["Matt Enlow", "Greg Mefford"],
       licenses: ["Apache-2.0"],
@@ -54,7 +54,7 @@ defmodule Styler.MixProject do
     ]
   end
 
-  defp docs do
+  defp docs() do
     [
       main: "readme",
       source_ref: "v#{@version}",

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -12,6 +12,53 @@ defmodule Styler.Style.ModuleDirectivesTest do
   @moduledoc false
   use Styler.StyleCase, async: true
 
+  describe "skip comment" do
+    test "skips module reordering" do
+      assert_style("""
+      defmodule Foo do
+        # elixir-styler:skip-module-reordering
+        @behaviour Lawful
+        require A
+        alias A.{A, B}
+
+        use B
+
+        def c(x), do: y
+
+        import C
+        @behaviour Chaotic
+        @doc "d doc"
+        def d() do
+          alias X.X
+          alias H.H
+
+          alias Z.Z
+          import Ecto.Query
+          X.foo()
+        end
+
+        @shortdoc "it's pretty short"
+        import A
+        alias C.C
+        alias D.D
+
+        require C
+        require B
+
+        use A
+
+        alias C.C
+        alias A.A
+
+        @moduledoc "README.md"
+                   |> File.read!()
+                   |> String.split("<!-- MDOC !-->")
+                   |> Enum.fetch!(1)
+      end
+      """)
+    end
+  end
+
   describe "defmodule features" do
     test "handles module with no directives" do
       assert_style("""

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -30,7 +30,10 @@ defmodule Styler.Style.SingleNodeTest do
   describe "{Keyword/Map}.merge/2 of a single key => *.put/3" do
     test "in a pipe" do
       for module <- ~w(Map Keyword) do
-        assert_style("foo |> #{module}.merge(%{one_key: :bar}) |> bop()", "foo |> #{module}.put(:one_key, :bar) |> bop()")
+        assert_style(
+          "foo |> #{module}.merge(%{one_key: :bar}) |> bop()",
+          "foo |> #{module}.put(:one_key, :bar) |> bop()"
+        )
       end
     end
 

--- a/test/support/style_case.ex
+++ b/test/support/style_case.ex
@@ -126,7 +126,11 @@ defmodule Styler.StyleCase do
         assert true
       else
         flunk(
-          format_diff(styled, restyled, "expected styling to be idempotent, but a second pass resulted in more changes.")
+          format_diff(
+            styled,
+            restyled,
+            "expected styling to be idempotent, but a second pass resulted in more changes."
+          )
         )
       end
     end

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -478,13 +478,14 @@ defmodule StylerTest.ZipperTest do
 
   describe "insert_child/2 and append_child/2" do
     test "add child nodes to the leftmost or rightmost side" do
-      assert [1, 2, 3] |> Zipper.zip() |> Zipper.insert_child(:first) |> Zipper.append_child(:last) |> Zipper.root() == [
-               :first,
-               1,
-               2,
-               3,
-               :last
-             ]
+      assert [1, 2, 3] |> Zipper.zip() |> Zipper.insert_child(:first) |> Zipper.append_child(:last) |> Zipper.root() ==
+               [
+                 :first,
+                 1,
+                 2,
+                 3,
+                 :last
+               ]
 
       assert {:left, :right} |> Zipper.zip() |> Zipper.insert_child(:first) |> Zipper.root() ==
                {:{}, [],
@@ -502,7 +503,11 @@ defmodule StylerTest.ZipperTest do
                   :last
                 ]}
 
-      assert {:foo, [], []} |> Zipper.zip() |> Zipper.insert_child(:first) |> Zipper.append_child(:last) |> Zipper.root() ==
+      assert {:foo, [], []}
+             |> Zipper.zip()
+             |> Zipper.insert_child(:first)
+             |> Zipper.append_child(:last)
+             |> Zipper.root() ==
                {:foo, [], [:first, :last]}
 
       assert {{:., [], [:a, :b]}, [], []}


### PR DESCRIPTION
For rare cases, reorganizing module directives will break code. We give an option to skip reordering if specified with the comment #elixir-styler:skip-module-reordering