### PR TITLE
Do not add @moduledoc false

### DIFF
--- a/docs/module_directives.md
+++ b/docs/module_directives.md
@@ -1,19 +1,3 @@
-## Adds Moduledoc
-
-Adds `@moduledoc false` to modules without a moduledoc unless the module's name ends with one of the following:
-
-* `Test`
-* `Mixfile`
-* `MixProject`
-* `Controller`
-* `Endpoint`
-* `Repo`
-* `Router`
-* `Socket`
-* `View`
-* `HTML`
-* `JSON`
-
 ## Directive Expansion
 
 Expands `Module.{SubmoduleA, SubmoduleB}` to their explicit forms for ease of searching.
@@ -38,7 +22,7 @@ alias Foo.Bop
 Modules directives are sorted into the following order:
 
 * `@shortdoc`
-* `@moduledoc` (adds `@moduledoc false`)
+* `@moduledoc`
 * `@behaviour`
 * `use`
 * `import` (sorted alphabetically)

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -50,7 +50,8 @@ defmodule Styler.Style.ModuleDirectives do
   @attr_directives ~w(moduledoc shortdoc behaviour)a
   @defstruct ~w(schema embedded_schema defstruct)a
 
-  @moduledoc_false {:@, [line: nil], [{:moduledoc, [line: nil], [{:__block__, [line: nil], [false]}]}]}
+  @module_placeholder "Xk9pLm3Qw7_RAND_PLACEHOLDER"
+  @moduledoc_false {:@, [line: nil], [{:moduledoc, [line: nil], [{:__block__, [line: nil], [@module_placeholder]}]}]}
 
   def run({{:defmodule, _, children}, _} = zipper, ctx) do
     [name, [{{:__block__, do_meta, [:do]}, _body}]] = children
@@ -131,6 +132,8 @@ defmodule Styler.Style.ModuleDirectives do
   end
 
   def run(zipper, ctx), do: {:cont, zipper, ctx}
+
+  def moduledoc_placeholder(), do: @module_placeholder
 
   defp moduledoc({:__aliases__, m, aliases}) do
     name = aliases |> List.last() |> to_string()

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -45,6 +45,16 @@ defmodule Styler do
         end
       end)
 
+      zipper = Zipper.zip(ast)
+      moduledoc_placeholder = Styler.Style.ModuleDirectives.moduledoc_placeholder()
+
+    {{ast, _}, _} =
+      Zipper.traverse_while(zipper, nil, fn
+        {{:@, _, [{:moduledoc, _, [{:__block__, _, [^moduledoc_placeholder]}]}]}, _} = z, _ ->
+          {:cont, Zipper.remove(z), nil}
+        z, _ ->
+          {:cont, z, nil}
+      end)
     {ast, comments}
   end
 

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -82,11 +82,9 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule A do
-        @moduledoc false
         alias A.B.C
 
         defmodule B do
-          @moduledoc false
           C.f()
           C.f()
         end
@@ -109,7 +107,6 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule Timely do
-        @moduledoc false
         use A.B.C
 
         import A.B.C
@@ -166,7 +163,6 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule A do
-        @moduledoc false
         alias A.B.C
 
         def lift_me() do
@@ -190,7 +186,6 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule A do
-        @moduledoc false
         alias A.B.C
 
         require B
@@ -217,7 +212,6 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule A do
-        @moduledoc false
         alias A.School
         alias A.SPOOL
         alias A.Stool
@@ -247,7 +241,6 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule A do
-        @moduledoc false
         alias A.SPOOL
         alias A.School
         alias A.Stool

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -49,53 +49,6 @@ defmodule Styler.Style.ModuleDirectivesTest do
     test "adds moduledoc" do
       assert_style(
         """
-        defmodule A do
-        end
-        """,
-        """
-        defmodule A do
-          @moduledoc false
-        end
-        """
-      )
-
-      assert_style(
-        """
-        defmodule B do
-          defmodule C do
-          end
-        end
-        """,
-        """
-        defmodule B do
-          @moduledoc false
-          defmodule C do
-            @moduledoc false
-          end
-        end
-        """
-      )
-
-      assert_style(
-        """
-        defmodule Bar do
-          alias Bop.Bop
-
-          :ok
-        end
-        """,
-        """
-        defmodule Bar do
-          @moduledoc false
-          alias Bop.Bop
-
-          :ok
-        end
-        """
-      )
-
-      assert_style(
-        """
         defmodule DocsOnly do
           @moduledoc "woohoo"
         end
@@ -110,12 +63,6 @@ defmodule Styler.Style.ModuleDirectivesTest do
       assert_style(
         """
         defmodule Foo do
-          use Bar
-        end
-        """,
-        """
-        defmodule Foo do
-          @moduledoc false
           use Bar
         end
         """
@@ -129,7 +76,6 @@ defmodule Styler.Style.ModuleDirectivesTest do
         """,
         """
         defmodule Foo do
-          @moduledoc false
           alias Foo.Bar
           alias Foo.Baz
         end
@@ -147,9 +93,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
         """,
         """
         defmodule A do
-          @moduledoc false
           defmodule B do
-            @moduledoc false
             :literal
           end
         end
@@ -516,6 +460,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
     assert_style(
       """
       defmodule F do
+        @moduledoc "This is a test"
         defstruct [:a]
         # comment for foo
         def foo, do: :ok
@@ -525,7 +470,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
       """,
       """
       defmodule F do
-        @moduledoc false
+        @moduledoc "This is a test"
         @derive Inspect
         @derive {Foo, bar: :baz}
         defstruct [:a]


### PR DESCRIPTION
Adding @moduledoc false does not have benefits and makes it easier to not add documentation. Therefore, we remove this feature.