### PR TITLE
Allow regex when specifying alias_lifting_excludes

### DIFF
--- a/docs/module_directives.md
+++ b/docs/module_directives.md
@@ -160,7 +160,7 @@ C.bar()
 
 Styler won't lift aliases that will collide with existing aliases, and likewise won't lift any module whose name would collide with a standard library name.
 
-You can specify additional modules to exclude from lifting via the `:alias_lifting_exclude` configuration option. For the example above, the following configuration would keep Styler from creating the `alias A.B.C` node:
+You can specify additional modules to exclude from lifting via the `:alias_lifting_exclude` configuration option. This option accepts both atoms and regexes. For the example above, the following configuration would keep Styler from creating the `alias A.B.C` node:
 
 ```elixir
 # .formatter.exs

--- a/lib/style/blocks.ex
+++ b/lib/style/blocks.ex
@@ -32,11 +32,7 @@ defmodule Styler.Style.Blocks do
   defguardp is_negator(n) when elem(n, 0) in [:!, :not, :!=, :!==]
 
   # Credo.Check.Refactor.CondStatements
-  def run(
-        {{:cond, _, [[{_, [{:->, _, [[head], a]}, {:->, _, [[{:__block__, _, [truthy]}], b]}]}]]},
-         _} = zipper,
-        ctx
-      )
+  def run({{:cond, _, [[{_, [{:->, _, [[head], a]}, {:->, _, [[{:__block__, _, [truthy]}], b]}]}]]}, _} = zipper, ctx)
       when is_atom(truthy) and truthy not in [nil, false],
       do: if_ast(zipper, head, a, b, ctx)
 
@@ -120,8 +116,7 @@ defmodule Styler.Style.Blocks do
               do_children = if node == :__block__, do: do_children, else: [do_body]
 
               do_body =
-                {:__block__, Keyword.take(do_body_meta, [:line]),
-                 Enum.reverse(postroll, do_children)}
+                {:__block__, Keyword.take(do_body_meta, [:line]), Enum.reverse(postroll, do_children)}
 
               {reversed_clauses, do_body}
 
@@ -333,9 +328,7 @@ defmodule Styler.Style.Blocks do
       end
 
     zipper
-    |> Zipper.replace(
-      {:if, [do: [line: line], end: [line: end_line], line: line], [head, [do_, else_]]}
-    )
+    |> Zipper.replace({:if, [do: [line: line], end: [line: end_line], line: line], [head, [do_, else_]]})
     |> run(%{ctx | comments: comments})
   end
 

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -367,10 +367,17 @@ defmodule Styler.Style.ModuleDirectives do
         {:skip, zipper, lifts}
 
       {{:__aliases__, _, [_, _, _ | _] = aliases}, _} = zipper, lifts ->
+        alias_string = Enum.join(aliases, ".")
+
+        excluded_regex_match =
+          excluded
+          |> Stream.filter(&is_struct(&1, Regex))
+          |> Enum.any?(&Regex.match?(&1, alias_string))
+
         last = List.last(aliases)
 
         lifts =
-          if last in excluded or not Enum.all?(aliases, &is_atom/1) do
+          if excluded_regex_match or last in excluded or not Enum.all?(aliases, &is_atom/1) do
             lifts
           else
             Map.update(lifts, last, {aliases, false}, fn

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -45,16 +45,18 @@ defmodule Styler do
         end
       end)
 
-      zipper = Zipper.zip(ast)
-      moduledoc_placeholder = Styler.Style.ModuleDirectives.moduledoc_placeholder()
+    zipper = Zipper.zip(ast)
+    moduledoc_placeholder = Styler.Style.ModuleDirectives.moduledoc_placeholder()
 
     {{ast, _}, _} =
       Zipper.traverse_while(zipper, nil, fn
         {{:@, _, [{:moduledoc, _, [{:__block__, _, [^moduledoc_placeholder]}]}]}, _} = z, _ ->
           {:cont, Zipper.remove(z), nil}
+
         z, _ ->
           {:cont, z, nil}
       end)
+
     {ast, comments}
   end
 

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -61,7 +61,8 @@ defmodule Styler.Config do
       end)
       |> MapSet.union(@stdlib)
 
-    reorder_configs = if is_nil(config[:reorder_configs]), do: true, else: config[:reorder_configs]
+    reorder_configs =
+      if is_nil(config[:reorder_configs]), do: true, else: config[:reorder_configs]
 
     :persistent_term.put(@key, %{
       block_pipe_flag: credo_opts[:block_pipe_flag] || false,

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -56,8 +56,11 @@ defmodule Styler.Config do
             _ -> atom
           end
 
+        regex when is_struct(regex, Regex) ->
+          regex
+
         other ->
-          raise "Expected an atom for `alias_lifting_exclude`, got: #{inspect(other)}"
+          raise "Expected an atom or regex for `alias_lifting_exclude`, got: #{inspect(other)}"
       end)
       |> MapSet.union(@stdlib)
 

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -312,6 +312,40 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       Styler.Config.set!([])
     end
 
+    test "collisions with configured regexes" do
+      Styler.Config.set!(alias_lifting_exclude: [~r/A.B/])
+
+      assert_style(
+        """
+        defmodule MyModule do
+          alias Foo.Bar
+
+          X.Y.Z.bar()
+          X.Y.Z.bar()
+          A.B.C.foo()
+          A.B.C.foo()
+          A.B.C.D.foo()
+          A.B.C.D.foo()
+        end
+        """,
+        """
+        defmodule MyModule do
+          alias Foo.Bar
+          alias X.Y.Z
+
+          Z.bar()
+          Z.bar()
+          A.B.C.foo()
+          A.B.C.foo()
+          A.B.C.D.foo()
+          A.B.C.D.foo()
+        end
+        """
+      )
+
+      Styler.Config.set!([])
+    end
+
     test "collisions with std lib" do
       assert_style """
       defmodule DontYouDare do

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -107,13 +107,11 @@ defmodule Styler.Style.ModuleDirectivesTest do
         """
       )
 
-      assert_style(
-        """
-        defmodule Foo do
-          use Bar
-        end
-        """
-      )
+      assert_style("""
+      defmodule Foo do
+        use Bar
+      end
+      """)
 
       assert_style(
         """


### PR DESCRIPTION
Sometimes, we want a whole family of modules to be excluded from alias lifting. For example, we may want to exclude every module that starts with `MyModule`. Therefore, allow regex to specify modules not to lift.