### PR TITLE
Use credo config for pipe chain start refactors

### DIFF
--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -349,9 +349,6 @@ defmodule Styler.Style.Pipes do
 
   defp custom_macro?(meta), do: Keyword.has_key?(meta, :do)
 
-  defp first_arg_excluded_type?([{:@, _, _} | _]),
-    do: :const in Styler.Config.pipe_chain_start_excluded_argument_types()
-
   defp first_arg_excluded_type?([{:%{}, _, _} | _]),
     do: :map in Styler.Config.pipe_chain_start_excluded_argument_types()
 

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -16,6 +16,7 @@ defmodule Styler.Config do
   alias Credo.Check.Readability.MaxLineLength
   alias Credo.Check.Readability.ParenthesesOnZeroArityDefs
   alias Credo.Check.Readability.SinglePipe
+  alias Credo.Check.Refactor.PipeChainStart
   alias Styler.Style.Configs
 
   @key __MODULE__
@@ -73,6 +74,9 @@ defmodule Styler.Config do
       block_pipe_exclude: credo_opts[:block_pipe_exclude] || [],
       lifting_excludes: excludes,
       line_length: credo_opts[:line_length] || 98,
+      pipe_chain_start_flag: credo_opts[:pipe_chain_start_flag] || false,
+      pipe_chain_start_excluded_functions: credo_opts[:pipe_chain_start_excluded_functions] || [],
+      pipe_chain_start_excluded_argument_types: credo_opts[:pipe_chain_start_excluded_argument_types] || [],
       reorder_configs: reorder_configs,
       single_pipe_flag: credo_opts[:single_pipe_flag] || false,
       sort_order: credo_opts[:sort_order] || :alpha,
@@ -115,6 +119,18 @@ defmodule Styler.Config do
     get(:line_length)
   end
 
+  def pipe_chain_start_excluded_functions() do
+    get(:pipe_chain_start_excluded_functions)
+  end
+
+  def pipe_chain_start_excluded_argument_types() do
+    get(:pipe_chain_start_excluded_argument_types)
+  end
+
+  def refactor_pipe_chain_starts?() do
+    get(:pipe_chain_start_flag)
+  end
+
   def single_pipe_flag?() do
     get(:single_pipe_flag)
   end
@@ -136,14 +152,21 @@ defmodule Styler.Config do
         Map.put(acc, :sort_order, opts[:sort_method])
 
       {BlockPipe, opts}, acc when is_list(opts) ->
-        Map.put(acc, :block_pipe_flag, true)
-        Map.put(acc, :block_pipe_exclude, opts[:exclude])
+        acc
+        |> Map.put(:block_pipe_flag, true)
+        |> Map.put(:block_pipe_exclude, opts[:exclude])
 
       {MaxLineLength, opts}, acc when is_list(opts) ->
         Map.put(acc, :line_length, opts[:max_length])
 
       {ParenthesesOnZeroArityDefs, opts}, acc when is_list(opts) ->
         Map.put(acc, :zero_arity_parens, opts[:parens])
+
+      {PipeChainStart, opts}, acc when is_list(opts) ->
+        acc
+        |> Map.put(:pipe_chain_start_flag, true)
+        |> Map.put(:pipe_chain_start_excluded_functions, opts[:excluded_functions])
+        |> Map.put(:pipe_chain_start_excluded_argument_types, opts[:excluded_argument_types])
 
       {SinglePipe, opts}, acc when is_list(opts) ->
         Map.put(acc, :single_pipe_flag, true)

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -13,9 +13,11 @@ defmodule Styler.Style.PipesTest do
 
   setup do
     Styler.Config.set_for_test!(:single_pipe_flag, true)
+    Styler.Config.set_for_test!(:pipe_chain_start_flag, true)
 
     on_exit(fn ->
       Styler.Config.set_for_test!(:single_pipe_flag, false)
+      Styler.Config.set_for_test!(:pipe_chain_start_flag, false)
     end)
 
     :ok
@@ -635,6 +637,7 @@ defmodule Styler.Style.PipesTest do
       Styler.Config.set_for_test!(:block_pipe_flag, false)
     end
   end
+
   describe "single pipe when credo check disabled" do
     setup do
       Styler.Config.set_for_test!(:single_pipe_flag, false)
@@ -1044,6 +1047,259 @@ defmodule Styler.Style.PipesTest do
 
                    excluded_first = MapSet.union(aliased, @excluded_namespaces)
                    """
+    end
+  end
+
+  describe "n-arity functions" do
+    test "doesn't extract >0 arity functions when disabled" do
+      Styler.Config.set_for_test!(:pipe_chain_start_flag, false)
+
+      assert_style("""
+      M.f(a, b)
+      |> g()
+      |> h()
+      """)
+
+      assert_style("""
+      f(a, b)
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_flag, true)
+    end
+
+    test "doesn't extract >0 arity functions when function in excluded_functions" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_functions, ["f", "Enum.map"])
+
+      assert_style("""
+      f(a, b)
+      |> g()
+      |> h()
+      """)
+
+      assert_style("""
+      Enum.map([1, 2, 3], &(&1 * 2))
+      |> Enum.reverse()
+      |> Enum.sum()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_functions, [])
+    end
+
+    test "doesn't extract >0 arity functions with atom argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:atom])
+
+      assert_style("""
+      f(:my_atom)
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with binary argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:binary])
+
+      assert_style("""
+      f("my string", b, c)
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with bitstring argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:bitstring])
+
+      assert_style("""
+      f(<<1>>)
+      |> g()
+      |> h()
+      """)
+
+      assert_style("""
+      f(<<1::integer-size(8), 2::integer-size(8), 3::integer-size(8)>>)
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with boolean argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:boolean])
+
+      assert_style("""
+      f(true)
+      |> g()
+      |> h()
+      """)
+
+      assert_style("""
+      f(false)
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with const argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:const])
+
+      assert_style("""
+      defmodule Test do
+        @apple :myconst
+        def p() do
+          f(@apple)
+          |> g()
+          |> h()
+        end
+      end
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with list argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:list])
+
+      assert_style("""
+      f([1, 2, 3])
+      |> g()
+      |> h()
+      """)
+
+      assert_style("""
+      f([a: 1, b: 2, c: 3])
+      |> g()
+      |> h()
+      """,
+      """
+      f(a: 1, b: 2, c: 3)
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with keyword list argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:keyword])
+
+      assert_style("""
+      f(a: 1, b: 2, c: 3)
+      |> g()
+      |> h()
+      """)
+
+      assert_style(
+      """
+      f([a: 1, b: 2, c: 3])
+      |> g()
+      |> h()
+      """,
+      """
+      f(a: 1, b: 2, c: 3)
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with map argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:map])
+
+      assert_style("""
+      f(%{a: 1, b: 2})
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with function arguments" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:fn])
+
+      assert_style("""
+      f(&String.length/1)
+      |> g()
+      |> h()
+      """)
+
+      assert_style("""
+      f(fn x -> x * 2 end)
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with number argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:number])
+
+      assert_style("""
+      f(1)
+      |> g()
+      |> h()
+      """)
+
+      assert_style("""
+      f(1.0)
+      |> g()
+      |> h()
+      """)
+
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with regex argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:regex])
+
+      assert_style("""
+      Regex.run(~r/foo/, "foobar")
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "doesn't extract >0 arity functions with tuple argument" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:tuple])
+
+      assert_style("""
+      f({1, 2, 3})
+      |> g()
+      |> h()
+      """)
+
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+    end
+
+    test "extracts >0 arity functions with non-excluded argument types" do
+      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
+
+      assert_style(
+        """
+        f(x)
+        |> g()
+        |> h()
+        """,
+        """
+        x
+        |> f()
+        |> g()
+        |> h()
+        """
+      )
     end
   end
 end

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -1147,23 +1147,6 @@ defmodule Styler.Style.PipesTest do
       Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
     end
 
-    test "doesn't extract >0 arity functions with const argument" do
-      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:const])
-
-      assert_style("""
-      defmodule Test do
-        @apple :myconst
-        def p() do
-          f(@apple)
-          |> g()
-          |> h()
-        end
-      end
-      """)
-
-      Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [])
-    end
-
     test "doesn't extract >0 arity functions with list argument" do
       Styler.Config.set_for_test!(:pipe_chain_start_excluded_argument_types, [:list])
 


### PR DESCRIPTION
Credo.Check.Refactor.PipeChainStart is controversial, so we should check its setting before refactoring anything.